### PR TITLE
Fix for Issue#61: Restarting cacher will not reset the database and hardware data will persist. 

### DIFF
--- a/db.go
+++ b/db.go
@@ -16,24 +16,6 @@ func pqError(err error) *pq.Error {
 	return nil
 }
 
-func truncate(db *sql.DB) error {
-	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
-	if err != nil {
-		return errors.Wrap(err, "BEGIN transaction")
-	}
-
-	_, err = tx.Exec("TRUNCATE hardware")
-	if err != nil {
-		return errors.Wrap(err, "TRUNCATE")
-	}
-
-	err = tx.Commit()
-	if err != nil {
-		return errors.Wrap(err, "TRUNCATE")
-	}
-	return err
-}
-
 func deleteFromDB(ctx context.Context, db *sql.DB, id string) error {
 	tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -66,12 +66,6 @@ func connectDB() *sql.DB {
 		panic(err)
 	}
 	db.SetMaxOpenConns(50)
-	if err := truncate(db); err != nil {
-		if pqErr := pqError(err); pqErr != nil {
-			logger.With("detail", pqErr.Detail, "where", pqErr.Where).Error(err)
-		}
-		panic(err)
-	}
 	return db
 }
 


### PR DESCRIPTION
Root Cause of issue:
When cacher tries to start it calls connecetdb which was creating the connection with the db and calling the trauncate function which trucate the hardware table in the database because of which all the entries in the hardware table were being deleted.

Fix:
I have removed the tructate function because of which trucation of harware table will not happen and all the entries of harware table will persist as it is even after the restart of cacher.