### PR TITLE
add insecure support to grpc client

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -15,6 +15,14 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+func isTrue(s string) bool {
+	s = strings.ToLower(s)
+	if s == "1" || s == "t" || s == "true" {
+		return true
+	}
+	return false
+}
+
 func New(facility string) (cacher.CacherClient, error) {
 	lookupAuthority := func(service, facility string) (string, error) {
 		_, addrs, err := net.LookupSRV(service, "tcp", "cacher."+facility+".packet.net")
@@ -29,32 +37,43 @@ func New(facility string) (cacher.CacherClient, error) {
 		return fmt.Sprintf("%s:%d", strings.TrimSuffix(addrs[0].Target, "."), addrs[0].Port), nil
 	}
 
-	certURL := os.Getenv("CACHER_CERT_URL")
-	if certURL == "" {
-		auth, err := lookupAuthority("http", facility)
-		if err != nil {
-			return nil, err
+	var securityOption grpc.DialOption
+
+	insecure := os.Getenv("CACHER_INSECURE")
+
+	if isTrue(insecure) {
+		securityOption = grpc.WithInsecure()
+	} else {
+		certURL := os.Getenv("CACHER_CERT_URL")
+		if certURL == "" {
+			auth, err := lookupAuthority("http", facility)
+			if err != nil {
+				return nil, err
+			}
+			certURL = "https://" + auth + "/cert"
 		}
-		certURL = "https://" + auth + "/cert"
-	}
-	resp, err := http.Get(certURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "fetch cert")
-	}
-	defer resp.Body.Close()
+		resp, err := http.Get(certURL)
+		if err != nil {
+			return nil, errors.Wrap(err, "fetch cert")
+		}
+		defer resp.Body.Close()
 
-	certs, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.Wrap(err, "read cert")
+		certs, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, errors.Wrap(err, "read cert")
+		}
+
+		cp := x509.NewCertPool()
+		ok := cp.AppendCertsFromPEM(certs)
+		if !ok {
+			return nil, errors.New("parsing cert")
+		}
+		creds := credentials.NewClientTLSFromCert(cp, "")
+
+		securityOption = grpc.WithTransportCredentials(creds)
 	}
 
-	cp := x509.NewCertPool()
-	ok := cp.AppendCertsFromPEM(certs)
-	if !ok {
-		return nil, errors.New("parsing cert")
-	}
-	creds := credentials.NewClientTLSFromCert(cp, "")
-
+	var err error
 	grpcAuthority := os.Getenv("CACHER_GRPC_AUTHORITY")
 	if grpcAuthority == "" {
 		grpcAuthority, err = lookupAuthority("grpc", facility)
@@ -62,7 +81,8 @@ func New(facility string) (cacher.CacherClient, error) {
 			return nil, err
 		}
 	}
-	conn, err := grpc.Dial(grpcAuthority, grpc.WithTransportCredentials(creds))
+
+	conn, err := grpc.Dial(grpcAuthority, securityOption)
 	if err != nil {
 		return nil, errors.Wrap(err, "connect to cacher")
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/magiconair/properties v1.8.0 // indirect
 	github.com/mitchellh/mapstructure v0.0.0-20180511142126-bb74f1db0675 // indirect
 	github.com/packethost/packngo v0.1.1-0.20180510203711-dff6ec250ba6
-	github.com/packethost/pkg v0.0.0-20200422151836-417b049b48b1
+	github.com/packethost/pkg v0.0.0-20200706202351-0602817a2778
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/packethost/packngo v0.1.1-0.20180510203711-dff6ec250ba6 h1:rEwKdcnAFG
 github.com/packethost/packngo v0.1.1-0.20180510203711-dff6ec250ba6/go.mod h1:otzZQXgoO96RTzDB/Hycg0qZcXZsWJGJRSXbmEIJ+4M=
 github.com/packethost/pkg v0.0.0-20200422151836-417b049b48b1 h1:iDclrzE6G/J0AAtTYHiOsdNA5t78/KfRWM0a0k2cMpE=
 github.com/packethost/pkg v0.0.0-20200422151836-417b049b48b1/go.mod h1:GkI1SaiEDaO+JsKjtcMsn/eDSU4/GD8CMin2b03fQvE=
+github.com/packethost/pkg v0.0.0-20200706202351-0602817a2778 h1:kbgGwIHuGP20/KcEdXLooXS1CfSnnyXe0yHwIEJvHKw=
+github.com/packethost/pkg v0.0.0-20200706202351-0602817a2778/go.mod h1:GSv7cTtIjns4yc0pyajaM1RE/KE4djJONoblFIRDrxA=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=


### PR DESCRIPTION
when using a loadbalancer that's handling the tls termination for
cacher, cacher server doesn't handle the certificates itself. Due
to this, when attempting to have services which implement cacher's
client library, and happen to live within the same container
orchestrator, instead of having to go through the ingres, to handle
the tls termination, it would be preferred to talk directly to the
cacher container.

This adds support to allow the cacher client library to not attempt
to connect to cacher with the discovered certs.