### PR TITLE
Allow insecure client

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -6,10 +6,10 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/packethost/cacher/protos/cacher"
+	"github.com/packethost/pkg/env"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -29,7 +29,7 @@ func New(facility string) (cacher.CacherClient, error) {
 		return fmt.Sprintf("%s:%d", strings.TrimSuffix(addrs[0].Target, "."), addrs[0].Port), nil
 	}
 
-	certURL := os.Getenv("CACHER_CERT_URL")
+	certURL := env.Get("CACHER_CERT_URL")
 	if certURL == "" {
 		auth, err := lookupAuthority("http", facility)
 		if err != nil {
@@ -55,7 +55,7 @@ func New(facility string) (cacher.CacherClient, error) {
 	}
 	creds := credentials.NewClientTLSFromCert(cp, "")
 
-	grpcAuthority := os.Getenv("CACHER_GRPC_AUTHORITY")
+	grpcAuthority := env.Get("CACHER_GRPC_AUTHORITY")
 	if grpcAuthority == "" {
 		grpcAuthority, err = lookupAuthority("grpc", facility)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/magiconair/properties v1.8.0 // indirect
 	github.com/mitchellh/mapstructure v0.0.0-20180511142126-bb74f1db0675 // indirect
 	github.com/packethost/packngo v0.1.1-0.20180510203711-dff6ec250ba6
-	github.com/packethost/pkg v0.0.0-20200422151836-417b049b48b1
+	github.com/packethost/pkg v0.0.0-20200807181840-a2cb6bbc41b9
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/packethost/packngo v0.1.1-0.20180510203711-dff6ec250ba6 h1:rEwKdcnAFG
 github.com/packethost/packngo v0.1.1-0.20180510203711-dff6ec250ba6/go.mod h1:otzZQXgoO96RTzDB/Hycg0qZcXZsWJGJRSXbmEIJ+4M=
 github.com/packethost/pkg v0.0.0-20200422151836-417b049b48b1 h1:iDclrzE6G/J0AAtTYHiOsdNA5t78/KfRWM0a0k2cMpE=
 github.com/packethost/pkg v0.0.0-20200422151836-417b049b48b1/go.mod h1:GkI1SaiEDaO+JsKjtcMsn/eDSU4/GD8CMin2b03fQvE=
+github.com/packethost/pkg v0.0.0-20200807181840-a2cb6bbc41b9 h1:BikdQN3TbmCk9uMYgmy6vt3Wzefn7D3a1n2SiJN1J/s=
+github.com/packethost/pkg v0.0.0-20200807181840-a2cb6bbc41b9/go.mod h1:GSv7cTtIjns4yc0pyajaM1RE/KE4djJONoblFIRDrxA=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=


### PR DESCRIPTION
This allows for clients to connect directly to the cacher server within a cluster where the ingress terminates the tls.