### PR TITLE
GRPC health-check for Cacher

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/packethost/cacher/hardware"
+	"github.com/packethost/cacher/pkg/healthcheck"
 	"github.com/packethost/cacher/protos/cacher"
 	"github.com/packethost/packngo"
 	"github.com/packethost/pkg/env"
@@ -20,6 +21,8 @@ import (
 	"github.com/packethost/pkg/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 var (
@@ -51,6 +54,7 @@ func setupGRPC(ctx context.Context, client *packngo.Client, facility string, err
 	}
 	s, err := grpc.NewServer(logger, func(s *grpc.Server) {
 		cacher.RegisterCacherServer(s.Server(), server)
+		grpc_health_v1.RegisterHealthServer(s.Server(), healthcheck.GrpcHealthChecker())
 	})
 	if err != nil {
 		logger.Fatal(errors.Wrap(err, "setup grpc server"))

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1,0 +1,30 @@
+// Package healthcheck provides service to get grpc server health status.
+package healthcheck
+
+import (
+	"context"
+
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// HealthChecker for grpc server.
+type HealthChecker struct{}
+
+// Check status and returns grpc healthcheckresponse
+func (s *HealthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	}, nil
+}
+
+// Watch streams the server status change.
+func (s *HealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, server grpc_health_v1.Health_WatchServer) error {
+	return server.Send(&grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	})
+}
+
+// GrpcHealthChecker requests to check the grpc server health.
+func GrpcHealthChecker() *HealthChecker {
+	return &HealthChecker{}
+}


### PR DESCRIPTION
Add grpc health check for cacher

Test:
- modify docker-compose.yml to add ports and FACILITY.
- make run

- Install grpc_health_prob and run following command:
  grpc_health_probe -addr=localhost:port -tls -tls-no-verify=True -v

result on success : SERVING
