### PR TITLE
change secret env names to align with org-wide secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,8 +44,8 @@ jobs:
       if: ${{ startsWith(github.ref, 'refs/heads/master') }}
       with:
         registry: quay.io
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Install Go


### PR DESCRIPTION
This will allow the repo to consume the already-available org-wide secrets