### PR TITLE
Skip ingestion if CACHER_NO_INGEST envvar is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ protos/cacher/cacher.pb.go: protos/cacher/cacher.proto
 
 test: lint test-only
 
-test-only:
+test-only: server
 	CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic ${TEST_ARGS} ./...
 
 run: ${binaries}

--- a/ingest.go
+++ b/ingest.go
@@ -170,6 +170,16 @@ func copyInEach(hw *hardware.Hardware, data []map[string]interface{}) error {
 }
 
 func (s *server) ingest(ctx context.Context, api *url.URL, facility string) error {
+	if env.Bool("CACHER_NO_INGEST") {
+		cacherState.Set(2)
+
+		s.ingestReadyLock.Lock()
+		s.ingestDone = true
+		s.ingestReadyLock.Unlock()
+
+		return nil
+	}
+
 	logger.Info("ingestion is starting")
 	defer logger.Info("ingestion is done")
 	cacherState.Set(1)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestNoIngest(t *testing.T) {
+	t.Run("IngestEnabledFails", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, "./cacher-linux-x86_64")
+		cmd.Env = []string{}
+		err := cmd.Run()
+
+		assert.Error(t, err)
+		eerr, ok := err.(*exec.ExitError)
+		assert.True(t, ok)
+
+		assert.Equal(t, 2, eerr.ExitCode())
+	})
+	t.Run("IngestDisabled", func(t *testing.T) {
+		cmd := exec.Command("./cacher-linux-x86_64")
+		cmd.Env = []string{
+			"CACHER_NO_INGEST=true",
+		}
+		err := cmd.Start()
+		assert.NoError(t, err)
+
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			cmd.Process.Signal(syscall.SIGHUP)
+		}()
+
+		err = cmd.Wait()
+		assert.Error(t, err)
+
+		status, ok := cmd.ProcessState.Sys().(syscall.WaitStatus)
+		assert.True(t, ok)
+
+		fmt.Println(cmd.ProcessState.String())
+
+		assert.True(t, status.Signaled())
+		assert.Equal(t, syscall.SIGHUP, status.Signal())
+	})
+}


### PR DESCRIPTION
This way we can use cacher in docker-compose without
having to fake or add creds to talk to EMAPI.