### PR TITLE
SRE-98: Remove OpenTelemetry StreamInterceptor

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -22,7 +22,6 @@ func New(facility string) (cacher.CacherClient, error) {
 	// setup OpenTelemetry autoinstrumentation automatically on the gRPC client
 	dialOpts := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
-		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()),
 	}
 
 	useTLS := env.Bool("CACHER_USE_TLS", true)


### PR DESCRIPTION
The auto-instrumentation from this is creating a lot of noisy span
events without much valuable data. If we decide in the future that we
want to instrument the message processing in more detail, we can add
custom instrumentation instead.