### PR TITLE
inband otel traceparent propagation

### DIFF
--- a/hardware/hw.go
+++ b/hardware/hw.go
@@ -24,7 +24,7 @@ type Hardware struct {
 	logger *log.Logger
 	mu     sync.RWMutex
 	hw     map[id]struct {
-		j    string
+		j    string // raw json record
 		ips  map[netaddr.IP]bool
 		macs map[mac]bool
 	}
@@ -48,6 +48,7 @@ type hardware struct {
 			MAC string
 		}
 	} `json:"network_ports"`
+	Traceparent string `json:"_traceparent"` // for otel trace propagation
 }
 
 // The Option type describes functions that operate on Hardeare during New.

--- a/hardware/hw.go
+++ b/hardware/hw.go
@@ -48,7 +48,8 @@ type hardware struct {
 			MAC string
 		}
 	} `json:"network_ports"`
-	Traceparent string `json:"_traceparent"` // for otel trace propagation
+	// in-band propagation of w3c traceparent so it can make it to boots
+	Traceparent string `json:"traceparent"`
 }
 
 // The Option type describes functions that operate on Hardeare during New.

--- a/hardware/hw_test.go
+++ b/hardware/hw_test.go
@@ -416,10 +416,10 @@ func TestTraceparent(t *testing.T) {
 	}
 
 	jsons := []string{
-		`{"id": "` + uuid.New().String() + `", "_traceparent": "` + tps[0] + `"}`,
-		`{"id": "` + uuid.New().String() + `", "_traceparent": "` + tps[1] + `"}`,
-		`{"id": "` + uuid.New().String() + `", "_traceparent": "` + tps[2] + `"}`,
-		`{"id": "` + uuid.New().String() + `", "_traceparent": "` + tps[3] + `"}`,
+		`{"id": "` + uuid.New().String() + `", "traceparent": "` + tps[0] + `"}`,
+		`{"id": "` + uuid.New().String() + `", "traceparent": "` + tps[1] + `"}`,
+		`{"id": "` + uuid.New().String() + `", "traceparent": "` + tps[2] + `"}`,
+		`{"id": "` + uuid.New().String() + `", "traceparent": "` + tps[3] + `"}`,
 	}
 
 	hw := New()

--- a/hardware/hw_test.go
+++ b/hardware/hw_test.go
@@ -1,6 +1,7 @@
 package hardware
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -401,5 +402,35 @@ func TestByMAC(t *testing.T) {
 		j, err := hw.ByMAC("00:00:00:00:00:" + mac)
 		assert.NoError(err)
 		assert.Equal(j2, j)
+	}
+}
+
+func TestTraceparent(t *testing.T) {
+	assert := require.New(t)
+
+	tps := []string{
+		"",
+		"00-00000000000000000000000000000000-0000000000000000-00",
+		"00-6d2cd79aa1c04f5a6f579cdb932e07b3-d376ef33e09b1e05-01",
+		"00-d538560f791eb96185f34aa2bf6082a9-b98f3fb3157fae01-01",
+	}
+
+	jsons := []string{
+		`{"id": "` + uuid.New().String() + `", "_traceparent": "` + tps[0] + `"}`,
+		`{"id": "` + uuid.New().String() + `", "_traceparent": "` + tps[1] + `"}`,
+		`{"id": "` + uuid.New().String() + `", "_traceparent": "` + tps[2] + `"}`,
+		`{"id": "` + uuid.New().String() + `", "_traceparent": "` + tps[3] + `"}`,
+	}
+
+	hw := New()
+	for i, j := range jsons {
+		id, err := hw.Add(j)
+		assert.Nil(err)
+		js, err := hw.ByID(id) // retrieve the hw and make sure the tp survives
+		assert.Nil(err)
+		inst := hardware{}
+		err = json.Unmarshal([]byte(js), &inst)
+		assert.Nil(err)
+		assert.Equal(tps[i], inst.Traceparent)
 	}
 }


### PR DESCRIPTION
Adds a traceparent field to hardware records. There's an open PR to have the API service add the traceparent as an in-band key on the hardware data it pushes to cacher in addition to propagating via gRPC. The idea here is that the in-band value will be available to boots when it comes and fetches the hardware record, and can continue the trace.